### PR TITLE
Cleanup unused css imported in html.js

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,8 +1,4 @@
 import React from 'react'
-import 'scss/gatstrap.scss'
-import 'animate.css/animate.css'
-import 'prismjs/themes/prism-okaidia.css'
-import 'font-awesome/css/font-awesome.css'
 
 export default class HTML extends React.Component {
   render() {


### PR DESCRIPTION
Thanks for this simple template, I learned a lot from it. I now try to set-up a new website from scratch to learn more and trying to replicate pieces from here. 

I was puzzled why importing CSS and SCSS from the `html.js` wouldn't work. It turns out there is no need to import them here, the important imports are in the `layout.js`. Am I right with this assumption?