### PR TITLE
Remove bluebird and use native promise

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,4 @@
 const each = require('lodash/each')
-const Promise = require('bluebird')
 const path = require('path')
 const PostTemplate = path.resolve('./src/templates/index.js')
 


### PR DESCRIPTION
Since the `node-version` for this starter is `10.11.0`, it supports native `Promise` and thus using `bluebird` as a dependency for promise is redundant

Reference:
https://node.green/#ES2015-built-ins-Promise