### PR TITLE
Add __DEV__ global variable to webpack

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,9 @@
     "es6": true,
     "node": true
   },
+  "globals": {
+    "__DEV__": true
+  },
   "rules": {
     "prettier/prettier": [
       "error",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Install this starter (assuming Gatsby is installed) by running from your CLI:
 develop
 `gatsby develop`
 
+> Note:
+> When in develop mode there is a global variable called `__DEV__` that you can use in all your `components`. This can be particulary useful if you like to avoid injecting few third-party scripts / widgets etc. while on develop mode.
+
 ### Custom Theme
 
 `/src/scss/gatstrap.scss`

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -61,7 +61,7 @@ exports.createPages = ({ graphql, actions }) => {
   })
 }
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ actions, plugins, stage }) => {
   actions.setWebpackConfig({
     resolve: {
       alias: {
@@ -70,5 +70,10 @@ exports.onCreateWebpackConfig = ({ actions }) => {
         scss: path.resolve(__dirname, 'src/scss'),
       },
     },
+    plugins: [
+      plugins.define({
+        __DEV__: stage === `develop` || stage === `develop-html`,
+      }),
+    ],
   })
 }


### PR DESCRIPTION
This PR adds / injects `__DEV__` via webpack's define plugin.
Because of this we can conditionally require few third-party widgets like the facebook share / like making it available only only in production.

Eg.:
```
function ShareWidget() {
  return __DEV__ ? null : <iframe src="https://fb......" />
}
```