### PR TITLE
chore(ts): drop deprecated baseUrl, prep for TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,10 @@
     "isolatedModules": true,
     "allowJs": false,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
-      "components/*": ["src/components/*"],
-      "templates/*": ["src/templates/*"],
-      "scss/*": ["src/scss/*"]
+      "components/*": ["./src/components/*"],
+      "templates/*": ["./src/templates/*"],
+      "scss/*": ["./src/scss/*"]
     }
   },
   "include": ["src", "gatsby-config.ts", "gatsby-node.ts"],


### PR DESCRIPTION
## Summary
- TypeScript 6 で `baseUrl` が deprecated (TS 7 で削除予定) になるため事前に外す
- `moduleResolution: bundler` 配下では `paths` は tsconfig からの相対で解決されるため `baseUrl: "."` は不要
- `paths` の各エントリは `./src/...` に明示化して曖昧さを排除

これで Dependabot #695 (TypeScript 6) の build エラー (TS5101) が解消する見込み。

## Test plan
- [x] `pnpm typecheck` (TS 5.9.3, ローカル)
- [ ] CI green
- [ ] PR #695 (TS 6) の rebase 後に build pass を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)