### PR TITLE
chore(ts): SCSS module shim for TypeScript 6

### DIFF
--- a/src/scss-modules.d.ts
+++ b/src/scss-modules.d.ts
@@ -1,0 +1,2 @@
+declare module '*.scss'
+declare module '*.sass'


### PR DESCRIPTION
## Summary
- TS 6 で TS2882 (side-effect import に型宣言必須) が有効になり、`.scss` の副作用 import で型エラーが出る
- ambient module shim (`*.scss`, `*.sass`) を追加して tsc が受理するようにする
- TS 5.9 でも問題なく通る

これで PR #695 (TypeScript 6) の build pass に必要な最後のピース。

## Test plan
- [x] `pnpm typecheck` (TS 5.9.3 ローカル)
- [ ] CI green
- [ ] #695 rebase 後の build pass を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)